### PR TITLE
fix: dependency list in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIRED = [
     "progressbar",
     "torchlibrosa==0.0.7",
     "GitPython",
-    "streamlit>=1.12.0"
+    "streamlit>=1.12.0",
     "pyyaml",
 ]
 


### PR DESCRIPTION
This missing comma causes dependency to be resolved as `streamlit (>=1.12.0pyyaml)` for some package managers (e.g [pdm](https://github.com/pdm-project/pdm)).