### PR TITLE
Fixed compatibility with newer numpy interfaces, docs update, and clarified environment setup via Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
-## Changelog
+# Changelog
 
-- 2023-11-12: Fixed compatibility with newer numpy interfaces, docs update, and clarified environment setup via Docker (by @[francocm](https://github.com/francocm))
-- 2023-10-20: Fix to support newer `librosa` (by @[manmay-nakhashi](https://github.com/manmay-nakhashi))
-- 2022-09-03: Fix bugs on commandline voicefixer for windows users.
-- 2022-08-18: Add commandline voicefixer tool to the pip package.
+## 2023-11-12
+### by @[francocm](https://github.com/francocm)
+
+1. Integrated fixes by @[manmay-nakhashi](https://github.com/manmay-nakhashi) which include support for newer `librosa`. This is from PR https://github.com/haoheliu/voicefixer/pull/56 which was not merged to `main` yet.
+2. Fixed compatibility with newer NumPy interfaces, as `nn.utils.weight_norm` is now `nn.utils.parametrizations.weight_norm`.
+3. Added ability to initialise weights only - useful to cache the setup without processing any files, via a new argument switch `--weight_prepare`.
+4. Added `Dockerfile` that allows a clear easy replicable way of running the tool with exact environment setup.
+5. Docs fix: Clarified what the run modes mean.
+6. Docs fix: Removed hardcoded references to version 0.1.2 as these are not relevant from a docs perspective and by default latest should be used which is the default behaviour when version is not specified
+7. Docs fix: Moved Changelog into a separate `CHANGELOG.md` file.
+
+## 2023-10-20
+### by @[manmay-nakhashi](https://github.com/manmay-nakhashi)
+
+- 2023-10-20: Fix to support newer `librosa`
+
+## 2023-09-03
+### by @[haoheliu](https://github.com/haoheliu)
+
+- Fix bugs on commandline voicefixer for windows users.
+
+## 2023-08-18
+### by @[haoheliu](https://github.com/haoheliu)
+
+- Add commandline voicefixer tool to the pip package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## Changelog
+
+- 2023-11-12: Fixed compatibility with newer numpy interfaces, docs update, and clarified environment setup via Docker (by @[francocm](https://github.com/francocm))
+- 2023-10-20: Fix to support newer `librosa` (by @[manmay-nakhashi](https://github.com/manmay-nakhashi))
+- 2022-09-03: Fix bugs on commandline voicefixer for windows users.
+- 2022-08-18: Add commandline voicefixer tool to the pip package.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.11-bookworm
+
+ARG USERNAME=voicefixer
+ARG USER_UID=1000
+ARG USER_GID=1000
+ARG WORKDIR_PATH=/opt/voicefixer
+ENV PYTHONUNBUFFERED=1
+
+RUN pip install numpy==1.26.1 librosa==0.10.1 pytz progressbar mpmath zipp watchdog validators tzlocal \
+    tzdata tornado toolz toml tenacity sympy smmap six rpds-py pyyaml pyparsing pygments pyarrow protobuf \
+    pillow nvidia-nvtx-cu12 nvidia-nvjitlink-cu12 nvidia-nccl-cu12 nvidia-curand-cu12 nvidia-cufft-cu12 \
+    nvidia-cuda-runtime-cu12 nvidia-cuda-nvrtc-cu12 nvidia-cuda-cupti-cu12 nvidia-cublas-cu12 networkx mdurl \
+    MarkupSafe kiwisolver fsspec fonttools filelock cycler contourpy click cachetools blinker attrs triton \
+    referencing python-dateutil nvidia-cusparse-cu12 nvidia-cudnn-cu12 markdown-it-py jinja2 importlib-metadata \
+    gitdb rich pydeck pandas nvidia-cusolver-cu12 matplotlib jsonschema-specifications GitPython torchlibrosa \
+    torch jsonschema altair streamlit
+
+RUN mkdir -p ${WORKDIR_PATH}
+
+ADD . $WORKDIR_PATH
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m -d ${WORKDIR_PATH} $USERNAME \
+    && chown -R $USERNAME:$USERNAME ${WORKDIR_PATH}
+
+WORKDIR ${WORKDIR_PATH}
+USER $USERNAME
+ENV PATH="${PATH}:${WORKDIR_PATH}/.local/bin"
+
+RUN pip install .
+RUN voicefixer --weight_prepare
+
+ENTRYPOINT ["voicefixer"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
     - [Command line](#command-line)
     - [Desktop App](#desktop-app)
     - [Python Examples](#python-examples)
+    - [Docker](#docker)
     - [Others Features](#others-features)
   - [Materials](#materials)
   - [Change log](#change-log)
@@ -39,11 +40,20 @@ Please visit [demo page](https://haoheliu.github.io/demopage-voicefixer/) to vie
 
 ## Usage
 
+### Run Modes
+
+| Mode | Description |
+| ---- | ----------- |
+| `0`    | Original Model (suggested by default) |
+| `1`    | Add preprocessing module (remove higher frequency) |
+| `2`    | Train mode (might work sometimes on seriously degraded real speech) |
+| `all`  | Run all modes - will output 1 wav file for each supported mode. |
+
 ### Command line
 
 First, install voicefixer via pip:
 ```shell
-pip install voicefixer==0.1.2
+pip install voicefixer
 ```
 
 Process a file:
@@ -70,6 +80,11 @@ Run all modes:
 voicefixer --infile /path/to/input.wav --outfile /path/to/output.wav --mode all
 ```
 
+Pre-load the weights only without any actual processing:
+```shell
+voicefixer --weight_prepare
+```
+
 For more helper information please run:
 
 ```shell
@@ -82,7 +97,7 @@ voicefixer -h
 
 Install voicefixer via pip:
 ```shell script
-pip install voicefixer==0.1.2
+pip install voicefixer
 ```
 
 You can test audio samples on your desktop by running website (powered by [streamlit](https://streamlit.io/))
@@ -115,7 +130,7 @@ streamlit run test/streamlit.py
 
 First, install voicefixer via pip:
 ```shell script
-pip install voicefixer==0.1.2
+pip install voicefixer
 ```
 
 Then run the following scripts for a test run:
@@ -174,6 +189,42 @@ vocoder.oracle(fpath=os.path.join(git_root,"test/utterance/original/p360_001_mic
 
 You can clone this repo and try to run test.py inside the *test* folder.
 
+### Docker
+
+> Currently the the Docker image is not published and needs to be built locally, but this way you make sure you're running it with all the expected configuration.
+> The generated image size is about 10GB and that is mainly due to the dependencies that consume around 9.8GB on their own.
+
+> However, the layer containing `voicefixer` is the last added layer, making any rebuild if you change sources relatively small (~200MB at a time as the weights get refreshed on image build).
+
+The `Dockerfile` can be viewed [here](Dockerfile).
+
+After cloning the repo:
+
+#### OS Agnostic
+
+```shell
+# To build the image
+cd voicefixer
+docker build -t voicefixer:cpu .
+
+# To run the image
+docker run --rm -v "$(pwd)/data:/opt/voicefixer/data" voicefixer:cpu <all_other_cli_args_here>
+
+## Example: docker run --rm -v "$(pwd)/data:/opt/voicefixer/data" voicefixer:cpu --infile data/my-input.wav --outfile data/my-output.mode-all.wav --mode all
+```
+
+#### Wrapper script: Linux and MacOS
+```bash
+# To build the image
+cd voicefixer
+./docker-build-local.sh
+
+# To run the image
+./run.sh <all_other_cli_args_here>
+
+## Example: ./run.sh --infile data/my-input.wav --outfile data/my-output.mode-all.wav --mode all
+```
+
 ### Others Features
 
 - How to use your own vocoder, like pre-trained HiFi-Gan?
@@ -213,9 +264,3 @@ Note:
 ## Change log
 - 2022-09-03: Fix bugs on commandline voicefixer for windows users.
 - 2022-08-18: Add commandline voicefixer tool to the pip package.
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -262,5 +262,5 @@ Note:
 
 
 ## Change log
-- 2022-09-03: Fix bugs on commandline voicefixer for windows users.
-- 2022-08-18: Add commandline voicefixer tool to the pip package.
+
+See [CHANGELOG.md](CHANGELOG.md).

--- a/bin/voicefixer
+++ b/bin/voicefixer
@@ -91,6 +91,12 @@ if __name__ == "__main__":
         default=False,
         action="store_true",
     )
+    parser.add_argument(
+        "--weight_prepare",
+        help="Set this flag if you only want to trigger the weights download check without any other execution.",
+        default=False,
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
@@ -98,6 +104,9 @@ if __name__ == "__main__":
         cuda = True
     else:
         cuda = False
+
+    if args.weight_prepare:
+        exit(0)
 
     process_file, process_folder = check_arguments(args)
 

--- a/docker-build-local.sh
+++ b/docker-build-local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+docker build -t voicefixer:cpu .

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,11 @@ VERSION = "0.1.2"
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    "librosa>=0.8.1,<0.9.0",
+    "librosa",
     "matplotlib",
     "torch>=1.7.0",
     "progressbar",
-    "torchlibrosa==0.0.7",
+    "torchlibrosa",
     "GitPython",
     "streamlit>=1.12.0",
     "pyyaml",

--- a/voicefixer/__main__.py
+++ b/voicefixer/__main__.py
@@ -91,6 +91,12 @@ if __name__ == "__main__":
         default=False,
         action="store_true",
     )
+    parser.add_argument(
+        "--weight_prepare",
+        help="Set this flag if you only want to trigger the weights download check without any other execution.",
+        default=False,
+        action="store_true",
+    )
 
     args = parser.parse_args()
 
@@ -98,6 +104,9 @@ if __name__ == "__main__":
         cuda = True
     else:
         cuda = False
+
+    if args.weight_prepare:
+        exit(0)
 
     process_file, process_folder = check_arguments(args)
 

--- a/voicefixer/base.py
+++ b/voicefixer/base.py
@@ -20,11 +20,13 @@ class VoiceFixer(nn.Module):
             raise RuntimeError("Error 0: The checkpoint for analysis module (vf.ckpt) is not found in ~/.cache/voicefixer/analysis_module/checkpoints. \
                                 By default the checkpoint should be download automatically by this program. Something bad may happened.\
                                 But don't worry! Alternatively you can download it directly from Zenodo: https://zenodo.org/record/5600188/files/vf.ckpt?download=1.")
-        self._model.load_state_dict(
-            torch.load(
-                self.analysis_module_ckpt
-            )
-        )
+        saved_state_dict = torch.load(self.analysis_module_ckpt)
+        model_state_dict = self._model.state_dict()
+
+        new_state_dict = {k: v for k, v in saved_state_dict.items() if k in model_state_dict}
+
+        model_state_dict.update(new_state_dict)
+        self._model.load_state_dict(model_state_dict, strict=False)
         self._model.eval()
 
     def _load_wav_energy(self, path, sample_rate, threshold=0.95):

--- a/voicefixer/vocoder/model/generator.py
+++ b/voicefixer/vocoder/model/generator.py
@@ -31,23 +31,23 @@ class Generator(nn.Module):
         if self.use_condnet:
             cond_channels = Config.cond_channels
             self.condnet = nn.Sequential(
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(in_channels, cond_channels, kernel_size=3, padding=1)
                 ),
                 nn.ELU(),
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(cond_channels, cond_channels, kernel_size=3, padding=1)
                 ),
                 nn.ELU(),
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(cond_channels, cond_channels, kernel_size=3, padding=1)
                 ),
                 nn.ELU(),
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(cond_channels, cond_channels, kernel_size=3, padding=1)
                 ),
                 nn.ELU(),
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(cond_channels, cond_channels, kernel_size=3, padding=1)
                 ),
                 nn.ELU(),
@@ -72,7 +72,7 @@ class Generator(nn.Module):
         if self.out_channels == 1:
             self.generator = nn.Sequential(
                 nn.ReflectionPad1d(3),
-                nn.utils.weight_norm(nn.Conv1d(in_channels, channels, kernel_size=7)),
+                nn.utils.parametrizations.weight_norm(nn.Conv1d(in_channels, channels, kernel_size=7)),
                 act,
                 UpsampleNet(channels, channels // 2, self.upsample_scales[0], hp, 0),
                 ResStack(channels // 2, kernel_size[0], self.resstack_depth[0], hp),
@@ -93,7 +93,7 @@ class Generator(nn.Module):
                 ResStack(channels // 16, kernel_size[3], self.resstack_depth[3], hp),
                 act,
                 nn.ReflectionPad1d(3),
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(channels // 16, self.out_channels, kernel_size=7)
                 ),
                 nn.Tanh(),
@@ -102,7 +102,7 @@ class Generator(nn.Module):
             channels = Config.m_channels
             self.generator = nn.Sequential(
                 nn.ReflectionPad1d(3),
-                nn.utils.weight_norm(nn.Conv1d(in_channels, channels, kernel_size=7)),
+                nn.utils.parametrizations.weight_norm(nn.Conv1d(in_channels, channels, kernel_size=7)),
                 act,
                 UpsampleNet(channels, channels // 2, self.upsample_scales[0], hp),
                 ResStack(channels // 2, kernel_size[0], self.resstack_depth[0], hp),
@@ -114,7 +114,7 @@ class Generator(nn.Module):
                 ResStack(channels // 8, kernel_size[3], self.resstack_depth[2], hp),
                 act,
                 nn.ReflectionPad1d(3),
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(channels // 8, self.out_channels, kernel_size=7)
                 ),
                 nn.Tanh(),

--- a/voicefixer/vocoder/model/modules.py
+++ b/voicefixer/vocoder/model/modules.py
@@ -417,7 +417,7 @@ class DownsampleNet(nn.Module):
             padding=upsample_factor // 2 + upsample_factor % 2,
         )
 
-        self.layer = nn.utils.weight_norm(layer)
+        self.layer = nn.utils.parametrizations.weight_norm(layer)
 
     def forward(self, inputs):
         B, C, T = inputs.size()
@@ -456,16 +456,16 @@ class UpsampleNet(nn.Module):
                 padding=upsample_factor // 2 + upsample_factor % 2,
                 output_padding=upsample_factor % 2,
             )
-            self.layer = nn.utils.weight_norm(layer)
+            self.layer = nn.utils.parametrizations.weight_norm(layer)
         else:
             self.layer = nn.Sequential(
                 nn.ReflectionPad1d(1),
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(input_size, output_size * upsample_factor, kernel_size=3)
                 ),
                 nn.LeakyReLU(),
                 nn.ReflectionPad1d(1),
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(
                         output_size * upsample_factor,
                         output_size * upsample_factor,
@@ -474,7 +474,7 @@ class UpsampleNet(nn.Module):
                 ),
                 nn.LeakyReLU(),
                 nn.ReflectionPad1d(1),
-                nn.utils.weight_norm(
+                nn.utils.parametrizations.weight_norm(
                     nn.Conv1d(
                         output_size * upsample_factor,
                         output_size * upsample_factor,
@@ -540,7 +540,7 @@ class ResStack(nn.Module):
             return int((kernel_size * dilation - dilation) / 2)
 
         if self.use_shift_scale:
-            self.scale_conv = nn.utils.weight_norm(
+            self.scale_conv = nn.utils.parametrizations.weight_norm(
                 nn.Conv1d(
                     channel, 2 * channel, kernel_size=kernel_size, dilation=1, padding=1
                 )
@@ -551,7 +551,7 @@ class ResStack(nn.Module):
                 [
                     nn.Sequential(
                         nn.LeakyReLU(),
-                        nn.utils.weight_norm(
+                        nn.utils.parametrizations.weight_norm(
                             nn.Conv1d(
                                 channel,
                                 channel,
@@ -561,7 +561,7 @@ class ResStack(nn.Module):
                             )
                         ),
                         nn.LeakyReLU(),
-                        nn.utils.weight_norm(
+                        nn.utils.parametrizations.weight_norm(
                             nn.Conv1d(
                                 channel,
                                 channel,
@@ -746,7 +746,7 @@ class Conv(nn.Module):
             dilation=dilation,
             padding=self.padding,
         )
-        self.conv = nn.utils.weight_norm(self.conv)
+        self.conv = nn.utils.parametrizations.weight_norm(self.conv)
         nn.init.kaiming_normal_(self.conv.weight)
 
     def forward(self, tensor):
@@ -786,14 +786,14 @@ class ResBlock(nn.Module):
         )
         self.res_conv = nn.Conv1d(out_channels, in_channels, kernel_size=1)
         self.skip_conv = nn.Conv1d(out_channels, skip_channels, kernel_size=1)
-        self.res_conv = nn.utils.weight_norm(self.res_conv)
-        self.skip_conv = nn.utils.weight_norm(self.skip_conv)
+        self.res_conv = nn.utils.parametrizations.weight_norm(self.res_conv)
+        self.skip_conv = nn.utils.parametrizations.weight_norm(self.skip_conv)
 
         if self.local_conditioning:
             self.filter_conv_c = nn.Conv1d(cin_channels, out_channels, kernel_size=1)
             self.gate_conv_c = nn.Conv1d(cin_channels, out_channels, kernel_size=1)
-            self.filter_conv_c = nn.utils.weight_norm(self.filter_conv_c)
-            self.gate_conv_c = nn.utils.weight_norm(self.gate_conv_c)
+            self.filter_conv_c = nn.utils.parametrizations.weight_norm(self.filter_conv_c)
+            self.gate_conv_c = nn.utils.parametrizations.weight_norm(self.gate_conv_c)
 
     def forward(self, tensor, c=None):
         h_filter = self.filter_conv(tensor)
@@ -854,7 +854,7 @@ class ResStack2D(nn.Module):
             [
                 nn.Sequential(
                     nn.LeakyReLU(),
-                    nn.utils.weight_norm(
+                    nn.utils.parametrizations.weight_norm(
                         nn.Conv2d(
                             1,
                             self.channels,
@@ -864,7 +864,7 @@ class ResStack2D(nn.Module):
                         )
                     ),
                     nn.LeakyReLU(),
-                    nn.utils.weight_norm(
+                    nn.utils.parametrizations.weight_norm(
                         nn.Conv2d(
                             self.channels,
                             self.channels,
@@ -874,7 +874,7 @@ class ResStack2D(nn.Module):
                         )
                     ),
                     nn.LeakyReLU(),
-                    nn.utils.weight_norm(nn.Conv2d(self.channels, 1, kernel_size=1)),
+                    nn.utils.parametrizations.weight_norm(nn.Conv2d(self.channels, 1, kernel_size=1)),
                 )
                 for i in range(resstack_depth)
             ]

--- a/voicefixer/vocoder/model/res_msd.py
+++ b/voicefixer/vocoder/model/res_msd.py
@@ -2,7 +2,8 @@ import torch
 import torch.nn.functional as F
 import torch.nn as nn
 from torch.nn import Conv1d, ConvTranspose1d, AvgPool1d, Conv2d
-from torch.nn.utils import weight_norm, remove_weight_norm, spectral_norm
+from torch.nn.utils import remove_weight_norm, spectral_norm
+from torch.nn.utils.parametrizations import weight_norm
 
 LRELU_SLOPE = 0.1
 


### PR DESCRIPTION
# Summary

## Changes

1. Integrated fixes by @[manmay-nakhashi](https://github.com/manmay-nakhashi) which include support for newer `librosa`. This is from PR https://github.com/haoheliu/voicefixer/pull/56 which is not merged to `main` yet.
2. Fixed compatibility with newer NumPy interfaces, as `nn.utils.weight_norm` is now `nn.utils.parametrizations.weight_norm`.
3. Added ability to initialise weights only - useful to cache the setup without processing any files, via a new argument switch `--weight_prepare`.
4. Added `Dockerfile` that allows a clear easy replicable way of running the tool with exact environment setup.
5. Docs fix: Clarified what the run modes mean.
6. Docs fix: Removed hardcoded references to version 0.1.2 as these are not relevant from a docs perspective and by default latest should be used which is the default behaviour when version is not specified
7. Docs fix: Moved Changelog into a separate `CHANGELOG.md` file.

## Related PRs

* https://github.com/haoheliu/voicefixer/pull/56 