### PR TITLE
Fix removed experimental streamlit attribute

### DIFF
--- a/test/streamlit.py
+++ b/test/streamlit.py
@@ -9,7 +9,7 @@ from io import BytesIO
 from voicefixer import VoiceFixer
 
 
-@st.experimental_singleton
+@st.cache_resource
 def init_voicefixer():
     return VoiceFixer()
 


### PR DESCRIPTION
`@st.cache_resource` is the new name for `@st.experimental_singleton`.

Without this change, the demo doesn't run (with a fresh installation of the dependencies, particularly streamlit).

See: https://github.com/streamlit/streamlit/commit/9800da0ab727de87f7872845548b357a82bd4375